### PR TITLE
Implement WooCommerce label overrides

### DIFF
--- a/includes/language-overrides.php
+++ b/includes/language-overrides.php
@@ -1,2 +1,36 @@
 <?php
-// Placeholder for language-overrides.php
+/**
+ * Overrides WooCommerce text labels using custom settings.
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Replace default WooCommerce labels with custom values from plugin settings.
+ *
+ * @param string $translated  Translated text.
+ * @param string $text        Original text.
+ * @param string $domain      Text domain.
+ * @return string Modified text.
+ */
+function asc_override_woocommerce_labels($translated, $text, $domain)
+{
+    if ($domain !== 'woocommerce') {
+        return $translated;
+    }
+
+    $settings = get_option('asc_settings', array());
+
+    if ($text === 'Add to cart' && !empty($settings['cart_label'])) {
+        return $settings['cart_label'];
+    }
+
+    if ($text === 'Out of stock' && !empty($settings['sold_label'])) {
+        return $settings['sold_label'];
+    }
+
+    return $translated;
+}
+add_filter('gettext', 'asc_override_woocommerce_labels', 20, 3);


### PR DESCRIPTION
## Summary
- implement a filter to override WooCommerce text labels
- read custom labels from `asc_settings` option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885b2e489c08320ba6d1c8964f2f154