### PR TITLE
Implement language overrides for WooCommerce

### DIFF
--- a/includes/language-overrides.php
+++ b/includes/language-overrides.php
@@ -1,2 +1,27 @@
 <?php
-// Placeholder for language-overrides.php
+// Exit if accessed directly
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Override WooCommerce labels based on plugin settings
+ */
+add_filter('gettext', 'asc_override_woocommerce_labels', 20, 3);
+
+function asc_override_woocommerce_labels($translated_text, $text, $domain) {
+    // Only override WooCommerce strings
+    if ($domain === 'woocommerce') {
+        $settings = get_option('asc_settings');
+
+        // Custom "Add to cart" replacement
+        if ($text === 'Add to cart' && !empty($settings['cart_label'])) {
+            return esc_html($settings['cart_label']);
+        }
+
+        // Custom "Out of stock" replacement
+        if ($text === 'Out of stock' && !empty($settings['sold_label'])) {
+            return esc_html($settings['sold_label']);
+        }
+    }
+
+    return $translated_text;
+}


### PR DESCRIPTION
## Summary
- add language override functionality for WooCommerce labels

## Testing
- `php -l includes/language-overrides.php`
- `php -l art-storefront-customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_6885b33ba27883209b70fb9438880022