### PR TITLE
Implement WooCommerce template override hook

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -20,3 +20,4 @@ require_once plugin_dir_path(__FILE__) . 'includes/artist-profile.php';
 require_once plugin_dir_path(__FILE__) . 'includes/admin-tools.php';
 require_once plugin_dir_path(__FILE__) . 'includes/settings-page.php';
 require_once plugin_dir_path(__FILE__) . 'includes/language-overrides.php';
+require_once plugin_dir_path(__FILE__) . 'includes/template-overrides.php';

--- a/includes/template-overrides.php
+++ b/includes/template-overrides.php
@@ -1,0 +1,22 @@
+<?php
+// Override WooCommerce templates with plugin versions
+
+add_filter('woocommerce_locate_template', 'asc_override_product_template', 10, 3);
+
+/**
+ * Use custom template for single product pages if available.
+ *
+ * @param string $template      Default template path.
+ * @param string $template_name Template name requested by WooCommerce.
+ * @param string $template_path Template path within WooCommerce.
+ * @return string Modified template path.
+ */
+function asc_override_product_template($template, $template_name, $template_path) {
+    if ($template_name === 'single-product.php') {
+        $custom = plugin_dir_path(__FILE__) . '../templates/single-product-artwork.php';
+        if (file_exists($custom)) {
+            return $custom;
+        }
+    }
+    return $template;
+}


### PR DESCRIPTION
## Summary
- add a new include file to override the WooCommerce single product template
- load the template override file from the main plugin

## Testing
- `php -l includes/template-overrides.php`
- `php -l art-storefront-customizer.php`

------
https://chatgpt.com/codex/tasks/task_e_6885b43c3dd88320b99da919f126e22a