### PR TITLE
Add product badges hook

### DIFF
--- a/includes/badges.php
+++ b/includes/badges.php
@@ -1,2 +1,40 @@
 <?php
-// Placeholder for badges.php
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+/**
+ * Display custom badges below the product price on single product pages.
+ */
+function asc_display_product_badges() {
+    global $product;
+
+    if (!$product instanceof WC_Product) {
+        return;
+    }
+
+    $badges = array();
+
+    if (!$product->is_in_stock()) {
+        $badges[] = '🟥 Collected';
+    }
+
+    $certificate = get_post_meta($product->get_id(), 'asc_certificate', true);
+    if ('yes' === $certificate) {
+        $badges[] = '✅ Certificate Included';
+    }
+
+    $badges[] = '📦 Shipping Included';
+    $badges[] = '💯 14-Day Satisfaction Guarantee';
+
+    if (empty($badges)) {
+        return;
+    }
+
+    echo '<div class="asc-badges">';
+    foreach ($badges as $badge) {
+        echo '<span class="asc-badge">' . esc_html($badge) . '</span>';
+    }
+    echo '</div>';
+}
+add_action('woocommerce_single_product_summary', 'asc_display_product_badges', 11);


### PR DESCRIPTION
## Summary
- implement WooCommerce hook to display custom badges

## Testing
- `php -l art-storefront-customizer.php`
- `php -l includes/badges.php`
- `php -l includes/meta-boxes.php`
- `php -l includes/display-fields.php`
- `php -l includes/taxonomies.php`
- `php -l includes/artist-profile.php`
- `php -l includes/admin-tools.php`
- `php -l includes/settings-page.php`
- `php -l includes/language-overrides.php`
- `php -l templates/single-product-artwork.php`


------
https://chatgpt.com/codex/tasks/task_e_6885b39e55ec8320adb4d746f05831d6