### PR TITLE
Add textdomain loader

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -21,3 +21,15 @@ require_once plugin_dir_path(__FILE__) . 'includes/admin-tools.php';
 require_once plugin_dir_path(__FILE__) . 'includes/settings-page.php';
 require_once plugin_dir_path(__FILE__) . 'includes/language-overrides.php';
 require_once plugin_dir_path(__FILE__) . 'includes/template-overrides.php';
+
+/**
+ * Load plugin textdomain for translations.
+ */
+function asc_load_textdomain() {
+    load_plugin_textdomain(
+        'art-storefront-customizer',
+        false,
+        dirname(plugin_basename(__FILE__)) . '/languages'
+    );
+}
+add_action('init', 'asc_load_textdomain');


### PR DESCRIPTION
## Summary
- support internationalization by loading plugin textdomain

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885b9e1c6dc8320ad9694c05285ecb6