### PR TITLE
Add toggleable badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ The plugin adds an **Art Storefront** submenu under WordPress Settings. Here you
 - Out of Stock Label
 - Enable Framing Options
 - Enable Edition Print Fields
+- Display Shipping Badge
+- Display Guarantee Badge

--- a/includes/badges.php
+++ b/includes/badges.php
@@ -19,13 +19,21 @@ function asc_display_product_badges() {
         $badges[] = '🟥 Collected';
     }
 
-    $certificate = get_post_meta($product->get_id(), 'asc_certificate', true);
-    if ('yes' === $certificate) {
+    $certificate = get_post_meta($product->get_id(), '_asc_certificate_of_authenticity', true);
+    if ('1' === $certificate) {
         $badges[] = '✅ Certificate Included';
     }
 
-    $badges[] = '📦 Shipping Included';
-    $badges[] = '💯 14-Day Satisfaction Guarantee';
+    $settings = asc_get_settings();
+
+    $shipping_format = get_post_meta($product->get_id(), '_asc_shipping_format', true);
+    if (!empty($shipping_format) && !empty($settings['display_shipping_badge'])) {
+        $badges[] = '📦 Shipping Included';
+    }
+
+    if (!empty($settings['display_guarantee_badge'])) {
+        $badges[] = '💯 14-Day Satisfaction Guarantee';
+    }
 
     if (empty($badges)) {
         return;
@@ -37,4 +45,4 @@ function asc_display_product_badges() {
     }
     echo '</div>';
 }
-add_action('woocommerce_single_product_summary', 'asc_display_product_badges', 11);
+add_action('art_storefront_product_badges', 'asc_display_product_badges');

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -8,11 +8,13 @@ if (!defined('ABSPATH')) {
  */
 function asc_settings_init() {
     $defaults = array(
-        'enable_collector_mode'      => 0,
-        'add_to_cart_label'          => 'Collect Now',
-        'out_of_stock_label'         => 'Collected 🟥',
-        'enable_framing_options'     => 0,
-        'enable_edition_print_fields'=> 0,
+        'enable_collector_mode'       => 0,
+        'add_to_cart_label'           => 'Collect Now',
+        'out_of_stock_label'          => 'Collected 🟥',
+        'enable_framing_options'      => 0,
+        'enable_edition_print_fields' => 0,
+        'display_shipping_badge'      => 1,
+        'display_guarantee_badge'     => 1,
     );
 
     register_setting('asc_settings_group', 'asc_settings', 'asc_sanitize_settings');
@@ -55,6 +57,22 @@ function asc_settings_init() {
         'enable_edition_print_fields',
         __('Enable Edition Print Fields', 'art-storefront-customizer'),
         'asc_render_checkbox_enable_edition_print_fields',
+        'asc_settings',
+        'asc_main_section'
+    );
+
+    add_settings_field(
+        'display_shipping_badge',
+        __('Display Shipping Badge', 'art-storefront-customizer'),
+        'asc_render_checkbox_display_shipping_badge',
+        'asc_settings',
+        'asc_main_section'
+    );
+
+    add_settings_field(
+        'display_guarantee_badge',
+        __('Display Guarantee Badge', 'art-storefront-customizer'),
+        'asc_render_checkbox_display_guarantee_badge',
         'asc_settings',
         'asc_main_section'
     );
@@ -110,6 +128,8 @@ function asc_sanitize_settings($input) {
     $output['out_of_stock_label'] = isset($input['out_of_stock_label']) ? sanitize_text_field($input['out_of_stock_label']) : 'Collected 🟥';
     $output['enable_framing_options'] = isset($input['enable_framing_options']) ? 1 : 0;
     $output['enable_edition_print_fields'] = isset($input['enable_edition_print_fields']) ? 1 : 0;
+    $output['display_shipping_badge'] = isset($input['display_shipping_badge']) ? 1 : 0;
+    $output['display_guarantee_badge'] = isset($input['display_guarantee_badge']) ? 1 : 0;
 
     return $output;
 }
@@ -125,7 +145,9 @@ function asc_get_settings() {
         'add_to_cart_label'          => 'Collect Now',
         'out_of_stock_label'         => 'Collected 🟥',
         'enable_framing_options'     => 0,
-        'enable_edition_print_fields'=> 0,
+        'enable_edition_print_fields' => 0,
+        'display_shipping_badge'      => 1,
+        'display_guarantee_badge'     => 1,
     );
     $options = get_option('asc_settings', array());
     return wp_parse_args($options, $defaults);
@@ -163,5 +185,19 @@ function asc_render_checkbox_enable_edition_print_fields() {
     $options = asc_get_settings();
     ?>
     <input type="checkbox" id="enable_edition_print_fields" name="asc_settings[enable_edition_print_fields]" value="1" <?php checked($options['enable_edition_print_fields'], 1); ?> />
+    <?php
+}
+
+function asc_render_checkbox_display_shipping_badge() {
+    $options = asc_get_settings();
+    ?>
+    <input type="checkbox" id="display_shipping_badge" name="asc_settings[display_shipping_badge]" value="1" <?php checked($options['display_shipping_badge'], 1); ?> />
+    <?php
+}
+
+function asc_render_checkbox_display_guarantee_badge() {
+    $options = asc_get_settings();
+    ?>
+    <input type="checkbox" id="display_guarantee_badge" name="asc_settings[display_guarantee_badge]" value="1" <?php checked($options['display_guarantee_badge'], 1); ?> />
     <?php
 }


### PR DESCRIPTION
## Summary
- allow configuring shipping/guarantee badges
- use new product data for certificate badge
- output product badges on a custom action

## Testing
- `php -l includes/badges.php`
- `php -l includes/settings-page.php`
- `php -l art-storefront-customizer.php`

------
https://chatgpt.com/codex/tasks/task_e_6885ba3b59dc8320bf4e17b694e96523