### PR TITLE
Add gallery layout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ The plugin adds an **Art Storefront** submenu under WordPress Settings. Here you
 - Out of Stock Label
 - Enable Framing Options
 - Enable Edition Print Fields
+- Enable Gallery Layout
+
+To switch between the default and gallery layout, navigate to **Settings → Art Storefront** and toggle the **Enable Gallery Layout** option.

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -13,6 +13,7 @@ function asc_settings_init() {
         'out_of_stock_label'         => 'Collected 🟥',
         'enable_framing_options'     => 0,
         'enable_edition_print_fields'=> 0,
+        'enable_gallery_layout'      => 0,
     );
 
     register_setting('asc_settings_group', 'asc_settings', 'asc_sanitize_settings');
@@ -55,6 +56,14 @@ function asc_settings_init() {
         'enable_edition_print_fields',
         __('Enable Edition Print Fields', 'art-storefront-customizer'),
         'asc_render_checkbox_enable_edition_print_fields',
+        'asc_settings',
+        'asc_main_section'
+    );
+
+    add_settings_field(
+        'enable_gallery_layout',
+        __('Enable Gallery Layout', 'art-storefront-customizer'),
+        'asc_render_checkbox_enable_gallery_layout',
         'asc_settings',
         'asc_main_section'
     );
@@ -110,6 +119,7 @@ function asc_sanitize_settings($input) {
     $output['out_of_stock_label'] = isset($input['out_of_stock_label']) ? sanitize_text_field($input['out_of_stock_label']) : 'Collected 🟥';
     $output['enable_framing_options'] = isset($input['enable_framing_options']) ? 1 : 0;
     $output['enable_edition_print_fields'] = isset($input['enable_edition_print_fields']) ? 1 : 0;
+    $output['enable_gallery_layout'] = isset($input['enable_gallery_layout']) ? 1 : 0;
 
     return $output;
 }
@@ -126,6 +136,7 @@ function asc_get_settings() {
         'out_of_stock_label'         => 'Collected 🟥',
         'enable_framing_options'     => 0,
         'enable_edition_print_fields'=> 0,
+        'enable_gallery_layout'      => 0,
     );
     $options = get_option('asc_settings', array());
     return wp_parse_args($options, $defaults);
@@ -163,5 +174,12 @@ function asc_render_checkbox_enable_edition_print_fields() {
     $options = asc_get_settings();
     ?>
     <input type="checkbox" id="enable_edition_print_fields" name="asc_settings[enable_edition_print_fields]" value="1" <?php checked($options['enable_edition_print_fields'], 1); ?> />
+    <?php
+}
+
+function asc_render_checkbox_enable_gallery_layout() {
+    $options = asc_get_settings();
+    ?>
+    <input type="checkbox" id="enable_gallery_layout" name="asc_settings[enable_gallery_layout]" value="1" <?php checked($options['enable_gallery_layout'], 1); ?> />
     <?php
 }

--- a/includes/template-overrides.php
+++ b/includes/template-overrides.php
@@ -13,9 +13,12 @@ add_filter('woocommerce_locate_template', 'asc_override_product_template', 10, 3
  */
 function asc_override_product_template($template, $template_name, $template_path) {
     if ($template_name === 'single-product.php') {
-        $custom = plugin_dir_path(__FILE__) . '../templates/single-product-artwork.php';
-        if (file_exists($custom)) {
-            return $custom;
+        $settings = function_exists('asc_get_settings') ? asc_get_settings() : array();
+        if (!empty($settings['enable_gallery_layout'])) {
+            $custom = plugin_dir_path(__FILE__) . '../templates/single-product-artwork.php';
+            if (file_exists($custom)) {
+                return $custom;
+            }
         }
     }
     return $template;


### PR DESCRIPTION
## Summary
- add option to enable gallery layout from settings
- toggle template override based on gallery layout setting
- document gallery layout option in README

## Testing
- `php -l includes/settings-page.php`
- `php -l includes/template-overrides.php`
- `php -l art-storefront-customizer.php`
- `php -l templates/single-product-artwork.php`
- `find . -name '*.php' -print0 | xargs -0 -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6885ba6e3d0c8320b6046376c255a824