### PR TITLE
Fix meta key references in templates and badges

### DIFF
--- a/includes/badges.php
+++ b/includes/badges.php
@@ -19,8 +19,8 @@ function asc_display_product_badges() {
         $badges[] = '🟥 Collected';
     }
 
-    $certificate = get_post_meta($product->get_id(), 'asc_certificate', true);
-    if ('yes' === $certificate) {
+    $certificate = get_post_meta($product->get_id(), '_asc_certificate_of_authenticity', true);
+    if ('1' === $certificate) {
         $badges[] = '✅ Certificate Included';
     }
 

--- a/templates/single-product-artwork.php
+++ b/templates/single-product-artwork.php
@@ -51,22 +51,22 @@ global $product;
 <section class="product-details-dimensions">
     <h2>Details &amp; Dimensions</h2>
     <ul class="artwork-attributes">
-        <?php if ( $medium = get_post_meta( get_the_ID(), 'medium', true ) ) : ?>
+        <?php if ( $medium = get_post_meta( get_the_ID(), '_asc_medium', true ) ) : ?>
             <li><strong>Medium:</strong> <?php echo esc_html( $medium ); ?></li>
         <?php endif; ?>
-        <?php if ( $year = get_post_meta( get_the_ID(), 'year', true ) ) : ?>
+        <?php if ( $year = get_post_meta( get_the_ID(), '_asc_year_created', true ) ) : ?>
             <li><strong>Year:</strong> <?php echo esc_html( $year ); ?></li>
         <?php endif; ?>
-        <?php if ( $dimensions = get_post_meta( get_the_ID(), 'dimensions', true ) ) : ?>
+        <?php if ( $dimensions = get_post_meta( get_the_ID(), '_asc_dimensions', true ) ) : ?>
             <li><strong>Dimensions:</strong> <?php echo esc_html( $dimensions ); ?></li>
         <?php endif; ?>
-        <?php if ( $rarity = get_post_meta( get_the_ID(), 'rarity', true ) ) : ?>
+        <?php if ( $rarity = get_post_meta( get_the_ID(), '_asc_rarity', true ) ) : ?>
             <li><strong>Rarity:</strong> <?php echo esc_html( $rarity ); ?></li>
         <?php endif; ?>
-        <?php if ( $framed = get_post_meta( get_the_ID(), 'framed', true ) ) : ?>
+        <?php if ( $framed = get_post_meta( get_the_ID(), '_asc_framed', true ) ) : ?>
             <li><strong>Framed:</strong> <?php echo esc_html( $framed ); ?></li>
         <?php endif; ?>
-        <?php if ( $certificate = get_post_meta( get_the_ID(), 'certificate', true ) ) : ?>
+        <?php if ( $certificate = get_post_meta( get_the_ID(), '_asc_certificate_of_authenticity', true ) ) : ?>
             <li><strong>Certificate:</strong> <?php echo esc_html( $certificate ); ?></li>
         <?php endif; ?>
     </ul>


### PR DESCRIPTION
## Summary
- reference correct artwork meta keys in template
- check certificate authenticity badge with `_asc_certificate_of_authenticity`

## Testing
- `php -l templates/single-product-artwork.php`
- `php -l includes/badges.php`
- `find . -name '*.php' -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6885ba767f2c8320aa9b9cd588e0d742