### PR TITLE
Add stylesheet enqueue function

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -33,3 +33,14 @@ function asc_load_textdomain() {
     );
 }
 add_action('init', 'asc_load_textdomain');
+
+/**
+ * Enqueue plugin styles.
+ */
+function asc_enqueue_styles() {
+    wp_enqueue_style(
+        'art-storefront-customizer',
+        plugins_url('assets/style.css', __FILE__)
+    );
+}
+add_action('wp_enqueue_scripts', 'asc_enqueue_styles');


### PR DESCRIPTION
## Summary
- hook into `wp_enqueue_scripts` in `art-storefront-customizer.php`
- enqueue `assets/style.css` for the plugin front‑end

## Testing
- `php -l art-storefront-customizer.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6885bf20b1d883208ab4ee68681947ca