### PR TITLE
Localize badge labels

### DIFF
--- a/includes/badges.php
+++ b/includes/badges.php
@@ -16,23 +16,23 @@ function asc_display_product_badges() {
     $badges = array();
 
     if (!$product->is_in_stock()) {
-        $badges[] = '🟥 Collected';
+        $badges[] = __('🟥 Collected', 'art-storefront-customizer');
     }
 
     $certificate = get_post_meta($product->get_id(), '_asc_certificate_of_authenticity', true);
     if ('1' === $certificate) {
-        $badges[] = '✅ Certificate Included';
+        $badges[] = __('✅ Certificate Included', 'art-storefront-customizer');
     }
 
     $settings = asc_get_settings();
 
     $shipping_format = get_post_meta($product->get_id(), '_asc_shipping_format', true);
     if (!empty($shipping_format) && !empty($settings['display_shipping_badge'])) {
-        $badges[] = '📦 Shipping Included';
+        $badges[] = __('📦 Shipping Included', 'art-storefront-customizer');
     }
 
     if (!empty($settings['display_guarantee_badge'])) {
-        $badges[] = '💯 14-Day Satisfaction Guarantee';
+        $badges[] = __('💯 14-Day Satisfaction Guarantee', 'art-storefront-customizer');
     }
 
     if (empty($badges)) {

--- a/languages/art-storefront-customizer.pot
+++ b/languages/art-storefront-customizer.pot
@@ -18,6 +18,10 @@ msgstr ""
 msgid "Collected 🟥"
 msgstr ""
 
+#: includes/badges.php
+msgid "🟥 Collected"
+msgstr ""
+
 #: placeholder
 msgid "Medium"
 msgstr ""
@@ -44,4 +48,16 @@ msgstr ""
 
 #: placeholder
 msgid "14-Day Satisfaction Guarantee"
+msgstr ""
+
+#: includes/badges.php
+msgid "✅ Certificate Included"
+msgstr ""
+
+#: includes/badges.php
+msgid "📦 Shipping Included"
+msgstr ""
+
+#: includes/badges.php
+msgid "💯 14-Day Satisfaction Guarantee"
 msgstr ""

--- a/languages/asc.pot
+++ b/languages/asc.pot
@@ -104,3 +104,19 @@ msgstr ""
 #: includes/settings-page.php:70
 msgid "Art Storefront"
 msgstr ""
+
+#: includes/badges.php
+msgid "🟥 Collected"
+msgstr ""
+
+#: includes/badges.php
+msgid "✅ Certificate Included"
+msgstr ""
+
+#: includes/badges.php
+msgid "📦 Shipping Included"
+msgstr ""
+
+#: includes/badges.php
+msgid "💯 14-Day Satisfaction Guarantee"
+msgstr ""


### PR DESCRIPTION
## Summary
- wrap badge strings in translation calls
- update POT files for badge labels

## Testing
- `php -l includes/badges.php`


------
https://chatgpt.com/codex/tasks/task_e_6885bf23ee588320a928ce7ca4e4b573