### PR TITLE
Add WooCommerce active check

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -12,15 +12,38 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly.
 }
 
-require_once plugin_dir_path(__FILE__) . 'includes/meta-boxes.php';
-require_once plugin_dir_path(__FILE__) . 'includes/display-fields.php';
-require_once plugin_dir_path(__FILE__) . 'includes/taxonomies.php';
-require_once plugin_dir_path(__FILE__) . 'includes/badges.php';
-require_once plugin_dir_path(__FILE__) . 'includes/artist-profile.php';
-require_once plugin_dir_path(__FILE__) . 'includes/admin-tools.php';
-require_once plugin_dir_path(__FILE__) . 'includes/settings-page.php';
-require_once plugin_dir_path(__FILE__) . 'includes/language-overrides.php';
-require_once plugin_dir_path(__FILE__) . 'includes/template-overrides.php';
+/**
+ * Load all plugin files after verifying WooCommerce is active.
+ */
+function asc_init_plugin() {
+    if (!class_exists('WooCommerce')) {
+        add_action('admin_notices', 'asc_wc_inactive_notice');
+        return;
+    }
+
+    require_once plugin_dir_path(__FILE__) . 'includes/meta-boxes.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/display-fields.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/taxonomies.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/badges.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/artist-profile.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/admin-tools.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/settings-page.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/language-overrides.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/template-overrides.php';
+
+    add_action('init', 'asc_load_textdomain');
+}
+
+/**
+ * Display admin notice when WooCommerce is inactive.
+ */
+function asc_wc_inactive_notice() {
+    echo '<div class="notice notice-error"><p>' .
+         esc_html__('Art Storefront Customizer requires WooCommerce to be active.', 'art-storefront-customizer') .
+         '</p></div>';
+}
+
+add_action('plugins_loaded', 'asc_init_plugin');
 
 /**
  * Load plugin textdomain for translations.
@@ -32,4 +55,3 @@ function asc_load_textdomain() {
         dirname(plugin_basename(__FILE__)) . '/languages'
     );
 }
-add_action('init', 'asc_load_textdomain');


### PR DESCRIPTION
## Summary
- defer loading plugin files until WooCommerce is confirmed active
- show an admin notice if WooCommerce is missing

## Testing
- `php -l art-storefront-customizer.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6885bf27e37c83209e085917ef44ba39