### PR TITLE
Add uninstall hook

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -21,6 +21,9 @@ require_once plugin_dir_path(__FILE__) . 'includes/admin-tools.php';
 require_once plugin_dir_path(__FILE__) . 'includes/settings-page.php';
 require_once plugin_dir_path(__FILE__) . 'includes/language-overrides.php';
 require_once plugin_dir_path(__FILE__) . 'includes/template-overrides.php';
+require_once plugin_dir_path(__FILE__) . 'uninstall.php';
+
+register_uninstall_hook(__FILE__, 'asc_customizer_uninstall');
 
 /**
  * Load plugin textdomain for translations.

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Uninstall routines for the Art Storefront Customizer plugin.
+ */
+
+// Exit if accessed directly or uninstall not called from WordPress.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+/**
+ * Delete all post meta for each custom key.
+ */
+function asc_customizer_uninstall() {
+    // Delete plugin options.
+    delete_option( 'asc_settings' );
+
+    $meta_keys = array(
+        '_asc_medium',
+        '_asc_year_created',
+        '_asc_dimensions',
+        '_asc_rarity',
+        '_asc_framed',
+        '_asc_certificate_of_authenticity',
+        '_asc_shipping_format',
+    );
+
+    foreach ( $meta_keys as $meta_key ) {
+        delete_post_meta_by_key( $meta_key );
+    }
+}
+
+


### PR DESCRIPTION
## Summary
- clean up plugin data on uninstall
- run uninstall cleanup via register_uninstall_hook

## Testing
- `php -l art-storefront-customizer.php`
- `php -l uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_6885bf343b888320a012638289c1e5bd