### PR TITLE
Update collected badge icon

### DIFF
--- a/includes/badges.php
+++ b/includes/badges.php
@@ -16,7 +16,7 @@ function asc_display_product_badges() {
     $badges = array();
 
     if (!$product->is_in_stock()) {
-        $badges[] = __('🟥 Collected', 'art-storefront-customizer');
+        $badges[] = __('🔴 Collected', 'art-storefront-customizer');
     }
 
     $certificate = get_post_meta($product->get_id(), '_asc_certificate_of_authenticity', true);

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -10,7 +10,7 @@ function asc_settings_init() {
     $defaults = array(
         'enable_collector_mode'       => 0,
         'add_to_cart_label'           => 'Collect Now',
-        'out_of_stock_label'          => 'Collected 🟥',
+        'out_of_stock_label'          => 'Collected 🔴',
         'enable_framing_options'      => 0,
         'enable_edition_print_fields' => 0,
         'display_shipping_badge'      => 1,
@@ -125,7 +125,7 @@ function asc_sanitize_settings($input) {
 
     $output['enable_collector_mode'] = isset($input['enable_collector_mode']) ? 1 : 0;
     $output['add_to_cart_label'] = isset($input['add_to_cart_label']) ? sanitize_text_field($input['add_to_cart_label']) : 'Collect Now';
-    $output['out_of_stock_label'] = isset($input['out_of_stock_label']) ? sanitize_text_field($input['out_of_stock_label']) : 'Collected 🟥';
+    $output['out_of_stock_label'] = isset($input['out_of_stock_label']) ? sanitize_text_field($input['out_of_stock_label']) : 'Collected 🔴';
     $output['enable_framing_options'] = isset($input['enable_framing_options']) ? 1 : 0;
     $output['enable_edition_print_fields'] = isset($input['enable_edition_print_fields']) ? 1 : 0;
     $output['display_shipping_badge'] = isset($input['display_shipping_badge']) ? 1 : 0;
@@ -143,7 +143,7 @@ function asc_get_settings() {
     $defaults = array(
         'enable_collector_mode'      => 0,
         'add_to_cart_label'          => 'Collect Now',
-        'out_of_stock_label'         => 'Collected 🟥',
+        'out_of_stock_label'         => 'Collected 🔴',
         'enable_framing_options'     => 0,
         'enable_edition_print_fields' => 0,
         'display_shipping_badge'      => 1,

--- a/languages/art-storefront-customizer.pot
+++ b/languages/art-storefront-customizer.pot
@@ -15,11 +15,11 @@ msgid "Collect Now"
 msgstr ""
 
 #: placeholder
-msgid "Collected 🟥"
+msgid "Collected 🔴"
 msgstr ""
 
 #: includes/badges.php
-msgid "🟥 Collected"
+msgid "🔴 Collected"
 msgstr ""
 
 #: placeholder

--- a/languages/asc.pot
+++ b/languages/asc.pot
@@ -106,7 +106,7 @@ msgid "Art Storefront"
 msgstr ""
 
 #: includes/badges.php
-msgid "🟥 Collected"
+msgid "🔴 Collected"
 msgstr ""
 
 #: includes/badges.php


### PR DESCRIPTION
## Summary
- swap the red square emoji for a red circle when marking items as collected
- update default settings and translation templates

## Testing
- `php -l includes/badges.php`
- `php -l includes/settings-page.php`
- `php -l art-storefront-customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_688613cc770483208862b511ade0b110