### PR TITLE
Fix WP plugin metadata

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -6,7 +6,7 @@
  * Author: Your Name
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain: art-storefront-customizer-main
+ * Text Domain: art-storefront-customizer
  * Domain Path: /languages
 
 if (!defined('ABSPATH')) {
@@ -32,7 +32,7 @@ register_uninstall_hook(__FILE__, 'asc_customizer_uninstall');
  */
 function asc_enqueue_styles() {
     wp_enqueue_style(
-        'art-storefront-customizer-main',
+        'art-storefront-customizer',
         plugins_url('assets/style.css', __FILE__),
         array(),
         '0.1.0'

--- a/includes/admin-tools.php
+++ b/includes/admin-tools.php
@@ -8,8 +8,8 @@ if (!defined('ABSPATH')) {
  */
 function asc_admin_tools_menu() {
     add_management_page(
-        __('Art Storefront Utilities', 'art-storefront-customizer-main'),
-        __('Art Storefront Utilities', 'art-storefront-customizer-main'),
+        __('Art Storefront Utilities', 'art-storefront-customizer'),
+        __('Art Storefront Utilities', 'art-storefront-customizer'),
         'manage_options',
         'asc_admin_tools',
         'asc_render_admin_tools_page'
@@ -44,7 +44,7 @@ function asc_render_admin_tools_page() {
             }
         }
 
-        echo '<div class="updated"><p>' . esc_html__('Artwork updated.', 'art-storefront-customizer-main') . '</p></div>';
+        echo '<div class="updated"><p>' . esc_html__('Artwork updated.', 'art-storefront-customizer') . '</p></div>';
     }
 
     $products = get_posts(array(
@@ -57,31 +57,31 @@ function asc_render_admin_tools_page() {
 
     ?>
     <div class="wrap">
-        <h1><?php esc_html_e('Art Storefront Utilities', 'art-storefront-customizer-main'); ?></h1>
+        <h1><?php esc_html_e('Art Storefront Utilities', 'art-storefront-customizer'); ?></h1>
         <form method="post">
             <?php wp_nonce_field('asc_bulk_edit_artwork', 'asc_bulk_edit_nonce'); ?>
             <table class="form-table" role="presentation">
                 <tr>
-                    <th scope="row"><?php esc_html_e('Products', 'art-storefront-customizer-main'); ?></th>
+                    <th scope="row"><?php esc_html_e('Products', 'art-storefront-customizer'); ?></th>
                     <td>
                         <select name="product_ids[]" multiple size="5" style="min-width: 300px;">
                             <?php foreach ($products as $product) : ?>
                                 <option value="<?php echo esc_attr($product->ID); ?>"><?php echo esc_html($product->post_title); ?></option>
                             <?php endforeach; ?>
                         </select>
-                        <p class="description"><?php esc_html_e('Hold Ctrl/Command to select multiple products.', 'art-storefront-customizer-main'); ?></p>
+                        <p class="description"><?php esc_html_e('Hold Ctrl/Command to select multiple products.', 'art-storefront-customizer'); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="asc_medium"><?php esc_html_e('Medium', 'art-storefront-customizer-main'); ?></label></th>
+                    <th scope="row"><label for="asc_medium"><?php esc_html_e('Medium', 'art-storefront-customizer'); ?></label></th>
                     <td><input type="text" name="medium" id="asc_medium" class="regular-text" /></td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="asc_year_created"><?php esc_html_e('Year Created', 'art-storefront-customizer-main'); ?></label></th>
+                    <th scope="row"><label for="asc_year_created"><?php esc_html_e('Year Created', 'art-storefront-customizer'); ?></label></th>
                     <td><input type="number" name="year_created" id="asc_year_created" class="small-text" /></td>
                 </tr>
             </table>
-            <?php submit_button(__('Update Artworks', 'art-storefront-customizer-main')); ?>
+            <?php submit_button(__('Update Artworks', 'art-storefront-customizer')); ?>
         </form>
     </div>
     <?php
@@ -104,7 +104,7 @@ function asc_add_convert_row_action($actions, $post) {
         'asc_convert_' . $post->ID
     );
 
-    $actions['asc_convert_to_artwork'] = '<a href="' . esc_url($url) . '">' . esc_html__('Convert to Artwork', 'art-storefront-customizer-main') . '</a>';
+    $actions['asc_convert_to_artwork'] = '<a href="' . esc_url($url) . '">' . esc_html__('Convert to Artwork', 'art-storefront-customizer') . '</a>';
 
     return $actions;
 }
@@ -117,7 +117,7 @@ function asc_handle_convert_to_artwork() {
     $post_id = intval($_GET['post_id'] ?? 0);
 
     if (!$post_id || !current_user_can('edit_post', $post_id)) {
-        wp_die(__('Invalid request.', 'art-storefront-customizer-main'));
+        wp_die(__('Invalid request.', 'art-storefront-customizer'));
     }
 
     check_admin_referer('asc_convert_' . $post_id);

--- a/includes/artist-profile.php
+++ b/includes/artist-profile.php
@@ -8,15 +8,15 @@ if (!defined('ABSPATH')) {
  */
 function asc_register_artist_post_type() {
     $labels = array(
-        'name'               => __('Artists', 'art-storefront-customizer-main'),
-        'singular_name'      => __('Artist', 'art-storefront-customizer-main'),
-        'add_new_item'       => __('Add New Artist', 'art-storefront-customizer-main'),
-        'edit_item'          => __('Edit Artist', 'art-storefront-customizer-main'),
-        'new_item'           => __('New Artist', 'art-storefront-customizer-main'),
-        'view_item'          => __('View Artist', 'art-storefront-customizer-main'),
-        'search_items'       => __('Search Artists', 'art-storefront-customizer-main'),
-        'not_found'          => __('No artists found', 'art-storefront-customizer-main'),
-        'all_items'          => __('All Artists', 'art-storefront-customizer-main'),
+        'name'               => __('Artists', 'art-storefront-customizer'),
+        'singular_name'      => __('Artist', 'art-storefront-customizer'),
+        'add_new_item'       => __('Add New Artist', 'art-storefront-customizer'),
+        'edit_item'          => __('Edit Artist', 'art-storefront-customizer'),
+        'new_item'           => __('New Artist', 'art-storefront-customizer'),
+        'view_item'          => __('View Artist', 'art-storefront-customizer'),
+        'search_items'       => __('Search Artists', 'art-storefront-customizer'),
+        'not_found'          => __('No artists found', 'art-storefront-customizer'),
+        'all_items'          => __('All Artists', 'art-storefront-customizer'),
     );
 
     register_post_type(
@@ -39,7 +39,7 @@ add_action('init', 'asc_register_artist_post_type');
 function asc_add_artist_meta_box() {
     add_meta_box(
         'asc_artist_details',
-        __('Artist Details', 'art-storefront-customizer-main'),
+        __('Artist Details', 'art-storefront-customizer'),
         'asc_render_artist_meta_box',
         'artist',
         'normal',
@@ -60,11 +60,11 @@ function asc_render_artist_meta_box($post) {
     $website = get_post_meta($post->ID, '_asc_artist_website', true);
     ?>
     <p>
-        <label for="asc_artist_website"><?php esc_html_e('Website', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_artist_website"><?php esc_html_e('Website', 'art-storefront-customizer'); ?></label><br />
         <input type="text" name="asc_artist_website" id="asc_artist_website" value="<?php echo esc_attr($website); ?>" class="widefat" />
     </p>
     <p>
-        <label for="asc_artist_bio"><?php esc_html_e('Biography', 'art-storefront-customizer-main'); ?></label>
+        <label for="asc_artist_bio"><?php esc_html_e('Biography', 'art-storefront-customizer'); ?></label>
     </p>
     <?php
     wp_editor(
@@ -114,7 +114,7 @@ add_action('save_post_artist', 'asc_save_artist_meta_box');
 function asc_add_product_artist_meta_box() {
     add_meta_box(
         'asc_product_artist',
-        __('Associated Artist', 'art-storefront-customizer-main'),
+        __('Associated Artist', 'art-storefront-customizer'),
         'asc_render_product_artist_meta_box',
         'product',
         'side',
@@ -142,7 +142,7 @@ function asc_render_product_artist_meta_box($post) {
     );
 
     echo '<select name="asc_artist_id" id="asc_artist_id" style="width:100%;">';
-    echo '<option value="">' . esc_html__('— None —', 'art-storefront-customizer-main') . '</option>';
+    echo '<option value="">' . esc_html__('— None —', 'art-storefront-customizer') . '</option>';
     foreach ($artists as $artist) {
         echo '<option value="' . esc_attr($artist->ID) . '" ' . selected($current, $artist->ID, false) . '>' . esc_html($artist->post_title) . '</option>';
     }

--- a/includes/badges.php
+++ b/includes/badges.php
@@ -16,23 +16,23 @@ function asc_display_product_badges() {
     $badges = array();
 
     if (!$product->is_in_stock()) {
-        $badges[] = __('🔴 Collected', 'art-storefront-customizer-main');
+        $badges[] = __('🔴 Collected', 'art-storefront-customizer');
     }
 
     $certificate = get_post_meta($product->get_id(), '_asc_certificate_of_authenticity', true);
     if ('1' === $certificate) {
-        $badges[] = __('✅ Certificate Included', 'art-storefront-customizer-main');
+        $badges[] = __('✅ Certificate Included', 'art-storefront-customizer');
     }
 
     $settings = asc_get_settings();
 
     $shipping_format = get_post_meta($product->get_id(), '_asc_shipping_format', true);
     if (!empty($shipping_format) && !empty($settings['display_shipping_badge'])) {
-        $badges[] = __('📦 Shipping Included', 'art-storefront-customizer-main');
+        $badges[] = __('📦 Shipping Included', 'art-storefront-customizer');
     }
 
     if (!empty($settings['display_guarantee_badge'])) {
-        $badges[] = __('💯 14-Day Satisfaction Guarantee', 'art-storefront-customizer-main');
+        $badges[] = __('💯 14-Day Satisfaction Guarantee', 'art-storefront-customizer');
     }
 
     if (empty($badges)) {

--- a/includes/display-fields.php
+++ b/includes/display-fields.php
@@ -34,32 +34,32 @@ function asc_output_artwork_details() {
     $items = array();
 
     if ($medium) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Medium', 'art-storefront-customizer-main'), esc_html($medium));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Medium', 'art-storefront-customizer'), esc_html($medium));
     }
     if ($year) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Year Created', 'art-storefront-customizer-main'), esc_html($year));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Year Created', 'art-storefront-customizer'), esc_html($year));
     }
     if ($dimensions) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Dimensions', 'art-storefront-customizer-main'), esc_html($dimensions));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Dimensions', 'art-storefront-customizer'), esc_html($dimensions));
     }
     if ($rarity) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Rarity', 'art-storefront-customizer-main'), esc_html($rarity));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Rarity', 'art-storefront-customizer'), esc_html($rarity));
     }
     if ($framed) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Framed', 'art-storefront-customizer-main'), esc_html($framed));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Framed', 'art-storefront-customizer'), esc_html($framed));
     }
     if (!empty($settings['enable_framing_options']) && $frame) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Frame Option', 'art-storefront-customizer-main'), esc_html($frame));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Frame Option', 'art-storefront-customizer'), esc_html($frame));
     }
     if ($coa) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Certificate of Authenticity', 'art-storefront-customizer-main'), esc_html__('Included', 'art-storefront-customizer-main'));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Certificate of Authenticity', 'art-storefront-customizer'), esc_html__('Included', 'art-storefront-customizer'));
     }
     if ($shipping) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Shipping Format', 'art-storefront-customizer-main'), esc_html($shipping));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Shipping Format', 'art-storefront-customizer'), esc_html($shipping));
     }
     if (!empty($settings['enable_edition_print_fields']) && ($edition_no || $edition_sz)) {
         $value = trim($edition_no . ($edition_sz ? ' / ' . $edition_sz : ''));
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Edition', 'art-storefront-customizer-main'), esc_html($value));
+        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Edition', 'art-storefront-customizer'), esc_html($value));
     }
 
     if (!empty($items)) {

--- a/includes/meta-boxes.php
+++ b/includes/meta-boxes.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 function asc_add_artwork_details_meta_box() {
     add_meta_box(
         'asc_artwork_details',
-        __('Artwork Details', 'art-storefront-customizer-main'),
+        __('Artwork Details', 'art-storefront-customizer'),
         'asc_render_artwork_details_meta_box',
         'product',
         'normal',
@@ -20,7 +20,7 @@ function asc_add_framing_options_meta_box() {
     if (!empty($settings['enable_framing_options'])) {
         add_meta_box(
             'asc_framing_options',
-            __('Framing Options', 'art-storefront-customizer-main'),
+            __('Framing Options', 'art-storefront-customizer'),
             'asc_render_framing_options_meta_box',
             'product',
             'side',
@@ -35,7 +35,7 @@ function asc_add_edition_info_meta_box() {
     if (!empty($settings['enable_edition_print_fields'])) {
         add_meta_box(
             'asc_edition_info',
-            __('Edition Information', 'art-storefront-customizer-main'),
+            __('Edition Information', 'art-storefront-customizer'),
             'asc_render_edition_info_meta_box',
             'product',
             'side',
@@ -57,42 +57,42 @@ function asc_render_artwork_details_meta_box($post) {
     $shipping   = get_post_meta($post->ID, '_asc_shipping_format', true);
     ?>
     <p>
-        <label for="asc_medium"><?php esc_html_e('Medium', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_medium"><?php esc_html_e('Medium', 'art-storefront-customizer'); ?></label><br />
         <input type="text" name="asc_medium" id="asc_medium" value="<?php echo esc_attr($medium); ?>" class="widefat" />
     </p>
     <p>
-        <label for="asc_year_created"><?php esc_html_e('Year Created', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_year_created"><?php esc_html_e('Year Created', 'art-storefront-customizer'); ?></label><br />
         <input type="number" name="asc_year_created" id="asc_year_created" value="<?php echo esc_attr($year); ?>" class="small-text" />
     </p>
     <p>
-        <label for="asc_dimensions"><?php esc_html_e('Dimensions (W × H × D)', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_dimensions"><?php esc_html_e('Dimensions (W × H × D)', 'art-storefront-customizer'); ?></label><br />
         <input type="text" name="asc_dimensions" id="asc_dimensions" value="<?php echo esc_attr($dimensions); ?>" class="widefat" />
     </p>
     <p>
-        <label for="asc_rarity"><?php esc_html_e('Rarity', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_rarity"><?php esc_html_e('Rarity', 'art-storefront-customizer'); ?></label><br />
         <select name="asc_rarity" id="asc_rarity">
-            <option value="one-of-a-kind" <?php selected($rarity, 'one-of-a-kind'); ?>><?php esc_html_e('One-of-a-kind', 'art-storefront-customizer-main'); ?></option>
-            <option value="limited-edition" <?php selected($rarity, 'limited-edition'); ?>><?php esc_html_e('Limited Edition', 'art-storefront-customizer-main'); ?></option>
-            <option value="open-edition" <?php selected($rarity, 'open-edition'); ?>><?php esc_html_e('Open Edition', 'art-storefront-customizer-main'); ?></option>
+            <option value="one-of-a-kind" <?php selected($rarity, 'one-of-a-kind'); ?>><?php esc_html_e('One-of-a-kind', 'art-storefront-customizer'); ?></option>
+            <option value="limited-edition" <?php selected($rarity, 'limited-edition'); ?>><?php esc_html_e('Limited Edition', 'art-storefront-customizer'); ?></option>
+            <option value="open-edition" <?php selected($rarity, 'open-edition'); ?>><?php esc_html_e('Open Edition', 'art-storefront-customizer'); ?></option>
         </select>
     </p>
     <p>
-        <label for="asc_framed"><?php esc_html_e('Framed', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_framed"><?php esc_html_e('Framed', 'art-storefront-customizer'); ?></label><br />
         <input type="text" name="asc_framed" id="asc_framed" value="<?php echo esc_attr($framed); ?>" class="widefat" />
     </p>
     <p>
         <label for="asc_certificate_of_authenticity">
             <input type="checkbox" name="asc_certificate_of_authenticity" id="asc_certificate_of_authenticity" value="1" <?php checked($coa, '1'); ?> />
-            <?php esc_html_e('Certificate of Authenticity', 'art-storefront-customizer-main'); ?>
+            <?php esc_html_e('Certificate of Authenticity', 'art-storefront-customizer'); ?>
         </label>
     </p>
     <p>
-        <label for="asc_shipping_format"><?php esc_html_e('Shipping Format', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_shipping_format"><?php esc_html_e('Shipping Format', 'art-storefront-customizer'); ?></label><br />
         <select name="asc_shipping_format" id="asc_shipping_format">
-            <option value="rolled" <?php selected($shipping, 'rolled'); ?>><?php esc_html_e('Rolled', 'art-storefront-customizer-main'); ?></option>
-            <option value="crated" <?php selected($shipping, 'crated'); ?>><?php esc_html_e('Crated', 'art-storefront-customizer-main'); ?></option>
-            <option value="flat" <?php selected($shipping, 'flat'); ?>><?php esc_html_e('Flat', 'art-storefront-customizer-main'); ?></option>
-            <option value="other" <?php selected($shipping, 'other'); ?>><?php esc_html_e('Other', 'art-storefront-customizer-main'); ?></option>
+            <option value="rolled" <?php selected($shipping, 'rolled'); ?>><?php esc_html_e('Rolled', 'art-storefront-customizer'); ?></option>
+            <option value="crated" <?php selected($shipping, 'crated'); ?>><?php esc_html_e('Crated', 'art-storefront-customizer'); ?></option>
+            <option value="flat" <?php selected($shipping, 'flat'); ?>><?php esc_html_e('Flat', 'art-storefront-customizer'); ?></option>
+            <option value="other" <?php selected($shipping, 'other'); ?>><?php esc_html_e('Other', 'art-storefront-customizer'); ?></option>
         </select>
     </p>
     <?php
@@ -103,7 +103,7 @@ function asc_render_framing_options_meta_box($post) {
     $option = get_post_meta($post->ID, '_asc_frame_option', true);
     ?>
     <p>
-        <label for="asc_frame_option"><?php esc_html_e('Frame Option', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_frame_option"><?php esc_html_e('Frame Option', 'art-storefront-customizer'); ?></label><br />
         <input type="text" name="asc_frame_option" id="asc_frame_option" value="<?php echo esc_attr($option); ?>" class="widefat" />
     </p>
     <?php
@@ -115,11 +115,11 @@ function asc_render_edition_info_meta_box($post) {
     $size   = get_post_meta($post->ID, '_asc_edition_size', true);
     ?>
     <p>
-        <label for="asc_edition_number"><?php esc_html_e('Edition Number', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_edition_number"><?php esc_html_e('Edition Number', 'art-storefront-customizer'); ?></label><br />
         <input type="text" name="asc_edition_number" id="asc_edition_number" value="<?php echo esc_attr($number); ?>" class="small-text" />
     </p>
     <p>
-        <label for="asc_edition_size"><?php esc_html_e('Edition Size', 'art-storefront-customizer-main'); ?></label><br />
+        <label for="asc_edition_size"><?php esc_html_e('Edition Size', 'art-storefront-customizer'); ?></label><br />
         <input type="text" name="asc_edition_size" id="asc_edition_size" value="<?php echo esc_attr($size); ?>" class="small-text" />
     </p>
     <?php

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -23,7 +23,7 @@ function asc_settings_init() {
 
     add_settings_field(
         'enable_collector_mode',
-        __('Enable Collector Mode', 'art-storefront-customizer-main'),
+        __('Enable Collector Mode', 'art-storefront-customizer'),
         'asc_render_checkbox_enable_collector_mode',
         'asc_settings',
         'asc_main_section'
@@ -31,7 +31,7 @@ function asc_settings_init() {
 
     add_settings_field(
         'add_to_cart_label',
-        __('Add to Cart Label', 'art-storefront-customizer-main'),
+        __('Add to Cart Label', 'art-storefront-customizer'),
         'asc_render_add_to_cart_label',
         'asc_settings',
         'asc_main_section'
@@ -39,7 +39,7 @@ function asc_settings_init() {
 
     add_settings_field(
         'out_of_stock_label',
-        __('Out of Stock Label', 'art-storefront-customizer-main'),
+        __('Out of Stock Label', 'art-storefront-customizer'),
         'asc_render_out_of_stock_label',
         'asc_settings',
         'asc_main_section'
@@ -47,7 +47,7 @@ function asc_settings_init() {
 
     add_settings_field(
         'enable_framing_options',
-        __('Enable Framing Options', 'art-storefront-customizer-main'),
+        __('Enable Framing Options', 'art-storefront-customizer'),
         'asc_render_checkbox_enable_framing_options',
         'asc_settings',
         'asc_main_section'
@@ -55,7 +55,7 @@ function asc_settings_init() {
 
     add_settings_field(
         'enable_edition_print_fields',
-        __('Enable Edition Print Fields', 'art-storefront-customizer-main'),
+        __('Enable Edition Print Fields', 'art-storefront-customizer'),
         'asc_render_checkbox_enable_edition_print_fields',
         'asc_settings',
         'asc_main_section'
@@ -63,7 +63,7 @@ function asc_settings_init() {
 
     add_settings_field(
         'display_shipping_badge',
-        __('Display Shipping Badge', 'art-storefront-customizer-main'),
+        __('Display Shipping Badge', 'art-storefront-customizer'),
         'asc_render_checkbox_display_shipping_badge',
         'asc_settings',
         'asc_main_section'
@@ -71,7 +71,7 @@ function asc_settings_init() {
 
     add_settings_field(
         'display_guarantee_badge',
-        __('Display Guarantee Badge', 'art-storefront-customizer-main'),
+        __('Display Guarantee Badge', 'art-storefront-customizer'),
         'asc_render_checkbox_display_guarantee_badge',
         'asc_settings',
         'asc_main_section'
@@ -84,8 +84,8 @@ add_action('admin_init', 'asc_settings_init');
  */
 function asc_add_settings_page() {
     add_options_page(
-        __('Art Storefront Settings', 'art-storefront-customizer-main'),
-        __('Art Storefront', 'art-storefront-customizer-main'),
+        __('Art Storefront Settings', 'art-storefront-customizer'),
+        __('Art Storefront', 'art-storefront-customizer'),
         'manage_options',
         'asc_settings',
         'asc_render_settings_page'
@@ -102,7 +102,7 @@ function asc_render_settings_page() {
     }
     ?>
     <div class="wrap">
-        <h1><?php esc_html_e('Art Storefront Settings', 'art-storefront-customizer-main'); ?></h1>
+        <h1><?php esc_html_e('Art Storefront Settings', 'art-storefront-customizer'); ?></h1>
         <form action="options.php" method="post">
             <?php
             settings_fields('asc_settings_group'); // Adds nonce and option_page fields

--- a/includes/taxonomies.php
+++ b/includes/taxonomies.php
@@ -9,16 +9,16 @@ if (!defined('ABSPATH')) {
 function asc_register_product_taxonomies() {
     $taxonomies = array(
         'associated_artist' => array(
-            'singular' => __('Associated Artist', 'art-storefront-customizer-main'),
-            'plural'   => __('Associated Artists', 'art-storefront-customizer-main'),
+            'singular' => __('Associated Artist', 'art-storefront-customizer'),
+            'plural'   => __('Associated Artists', 'art-storefront-customizer'),
         ),
         'art_style' => array(
-            'singular' => __('Art Style', 'art-storefront-customizer-main'),
-            'plural'   => __('Art Styles', 'art-storefront-customizer-main'),
+            'singular' => __('Art Style', 'art-storefront-customizer'),
+            'plural'   => __('Art Styles', 'art-storefront-customizer'),
         ),
         'subject_matter' => array(
-            'singular' => __('Subject', 'art-storefront-customizer-main'),
-            'plural'   => __('Subjects', 'art-storefront-customizer-main'),
+            'singular' => __('Subject', 'art-storefront-customizer'),
+            'plural'   => __('Subjects', 'art-storefront-customizer'),
         ),
     );
 
@@ -33,15 +33,15 @@ function asc_register_product_taxonomies() {
                 'labels'            => array(
                     'name'              => $labels['plural'],
                     'singular_name'     => $labels['singular'],
-                    'search_items'      => sprintf(__('Search %s', 'art-storefront-customizer-main'), $labels['plural']),
-                    'all_items'         => sprintf(__('All %s', 'art-storefront-customizer-main'), $labels['plural']),
-                    'edit_item'         => sprintf(__('Edit %s', 'art-storefront-customizer-main'), $labels['singular']),
-                    'view_item'         => sprintf(__('View %s', 'art-storefront-customizer-main'), $labels['singular']),
-                    'update_item'       => sprintf(__('Update %s', 'art-storefront-customizer-main'), $labels['singular']),
-                    'add_new_item'      => sprintf(__('Add New %s', 'art-storefront-customizer-main'), $labels['singular']),
-                    'new_item_name'     => sprintf(__('New %s Name', 'art-storefront-customizer-main'), $labels['singular']),
-                    'parent_item'       => sprintf(__('Parent %s', 'art-storefront-customizer-main'), $labels['singular']),
-                    'parent_item_colon' => sprintf(__('Parent %s:', 'art-storefront-customizer-main'), $labels['singular']),
+                    'search_items'      => sprintf(__('Search %s', 'art-storefront-customizer'), $labels['plural']),
+                    'all_items'         => sprintf(__('All %s', 'art-storefront-customizer'), $labels['plural']),
+                    'edit_item'         => sprintf(__('Edit %s', 'art-storefront-customizer'), $labels['singular']),
+                    'view_item'         => sprintf(__('View %s', 'art-storefront-customizer'), $labels['singular']),
+                    'update_item'       => sprintf(__('Update %s', 'art-storefront-customizer'), $labels['singular']),
+                    'add_new_item'      => sprintf(__('Add New %s', 'art-storefront-customizer'), $labels['singular']),
+                    'new_item_name'     => sprintf(__('New %s Name', 'art-storefront-customizer'), $labels['singular']),
+                    'parent_item'       => sprintf(__('Parent %s', 'art-storefront-customizer'), $labels['singular']),
+                    'parent_item_colon' => sprintf(__('Parent %s:', 'art-storefront-customizer'), $labels['singular']),
                     'menu_name'         => $labels['plural'],
                 ),
             )

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Art Storefront Customizer ===
 Contributors: yourname
 Requires at least: 5.0
-Tested up to: 6.3
+Tested up to: 6.8
 Requires PHP: 7.2
 Stable tag: 0.1.0
 License: GPLv2 or later


### PR DESCRIPTION
## Summary
- update tested WordPress version
- match plugin text domain with the slug

## Testing
- `php -l art-storefront-customizer.php`
- `for f in includes/*.php; do php -l "$f"; done`
- `php -l uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68864af520208320aabfbb3fd5ba9266