### PR TITLE
Add WooCommerce requirement metadata

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -3,6 +3,7 @@
  * Plugin Name: Art Storefront Customizer
  * Description: Artist-friendly customizations for WooCommerce.
  * Version: 0.1.0
+ * Requires: WooCommerce
  * Author: Your Name
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: yourname
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.2
+Requires: WooCommerce
 Stable tag: 0.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- note that the plugin requires WooCommerce in plugin header
- document WooCommerce requirement in readme.txt

## Testing
- `php -l art-storefront-customizer.php`
- `find . -name '*.php' -not -path './.git/*' -print0 | xargs -0 -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68865168bb848320ae75d972edccfc35