### PR TITLE
Improve collector status display and edition info

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Art Storefront Customizer
  * Description: Artist-friendly customizations for WooCommerce.
- * Version: 0.1.0
+ * Version: 0.1.1
  * Author: El Trujillo
  * Author URI: https://eltrujillo.com
  * License: GPLv2 or later
@@ -23,6 +23,7 @@ require_once plugin_dir_path(__FILE__) . 'includes/admin-tools.php';
 require_once plugin_dir_path(__FILE__) . 'includes/settings-page.php';
 require_once plugin_dir_path(__FILE__) . 'includes/language-overrides.php';
 require_once plugin_dir_path(__FILE__) . 'includes/template-overrides.php';
+require_once plugin_dir_path(__FILE__) . 'includes/availability.php';
 require_once plugin_dir_path(__FILE__) . 'uninstall.php';
 
 register_uninstall_hook(__FILE__, 'asc_customizer_uninstall');

--- a/includes/availability.php
+++ b/includes/availability.php
@@ -1,0 +1,36 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Hide default out-of-stock notices for unique artworks.
+ *
+ * @param string     $html    Availability HTML.
+ * @param WC_Product $product WooCommerce product.
+ * @return string Modified HTML.
+ */
+function asc_hide_unique_out_of_stock_html($html, $product) {
+    $rarity = get_post_meta($product->get_id(), '_asc_rarity', true);
+    if (!$product->is_in_stock() && $rarity === 'one-of-a-kind') {
+        return '';
+    }
+    return $html;
+}
+add_filter('woocommerce_get_stock_html', 'asc_hide_unique_out_of_stock_html', 10, 2);
+
+/**
+ * Hide out-of-stock text string for unique artworks.
+ *
+ * @param string     $text    Availability text.
+ * @param WC_Product $product WooCommerce product.
+ * @return string Modified text.
+ */
+function asc_hide_unique_availability_text($text, $product) {
+    $rarity = get_post_meta($product->get_id(), '_asc_rarity', true);
+    if (!$product->is_in_stock() && $rarity === 'one-of-a-kind') {
+        return '';
+    }
+    return $text;
+}
+add_filter('woocommerce_get_availability_text', 'asc_hide_unique_availability_text', 10, 2);

--- a/includes/display-fields.php
+++ b/includes/display-fields.php
@@ -57,8 +57,25 @@ function asc_output_artwork_details() {
     if ($shipping) {
         $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Shipping Format', 'art-storefront-customizer'), esc_html($shipping));
     }
-    if (!empty($settings['enable_edition_print_fields']) && ($edition_no || $edition_sz)) {
-        $value = trim($edition_no . ($edition_sz ? ' / ' . $edition_sz : ''));
+    if (!empty($settings['enable_edition_print_fields']) && ($edition_no || $edition_sz || $rarity === 'open-edition' || $rarity === 'limited-edition')) {
+        $parts = array();
+        if ($edition_no && $edition_sz) {
+            $parts[] = $edition_no . ' / ' . $edition_sz;
+        } elseif ($edition_no) {
+            $parts[] = $edition_no;
+        } elseif ($edition_sz) {
+            $parts[] = __('of', 'art-storefront-customizer') . ' ' . $edition_sz;
+        }
+
+        if ($rarity === 'open-edition') {
+            $parts[] = __('Open Edition', 'art-storefront-customizer');
+        } elseif ($rarity === 'limited-edition' && empty($edition_no) && empty($edition_sz)) {
+            $parts[] = __('Closed Edition', 'art-storefront-customizer');
+        } elseif ($rarity === 'limited-edition') {
+            $parts[] = __('Closed Edition', 'art-storefront-customizer');
+        }
+
+        $value = implode(' ', $parts);
         $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Edition', 'art-storefront-customizer'), esc_html($value));
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: eltrujillo
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.2
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/templates/single-product-artwork.php
+++ b/templates/single-product-artwork.php
@@ -16,10 +16,10 @@ global $product;
 
 <section class="product-summary">
     <h1 class="product_title entry-title"><?php the_title(); ?></h1>
+    <?php do_action( 'art_storefront_product_badges' ); ?>
     <div class="product-price">
         <?php wc_get_template( 'single-product/price.php' ); ?>
     </div>
-    <?php do_action( 'art_storefront_product_badges' ); ?>
 </section>
 
 <section class="product-main columns-2">
@@ -62,6 +62,29 @@ global $product;
         <?php endif; ?>
         <?php if ( $rarity = get_post_meta( get_the_ID(), '_asc_rarity', true ) ) : ?>
             <li><strong>Rarity:</strong> <?php echo esc_html( $rarity ); ?></li>
+        <?php endif; ?>
+        <?php
+        $edition_no   = get_post_meta( get_the_ID(), '_asc_edition_number', true );
+        $edition_size = get_post_meta( get_the_ID(), '_asc_edition_size', true );
+        $show_edition = $edition_no || $edition_size || $rarity === 'open-edition' || $rarity === 'limited-edition';
+        if ( $show_edition ) :
+            $parts = array();
+            if ( $edition_no && $edition_size ) {
+                $parts[] = $edition_no . ' / ' . $edition_size;
+            } elseif ( $edition_no ) {
+                $parts[] = $edition_no;
+            } elseif ( $edition_size ) {
+                $parts[] = __( 'of', 'art-storefront-customizer' ) . ' ' . $edition_size;
+            }
+            if ( $rarity === 'open-edition' ) {
+                $parts[] = __( 'Open Edition', 'art-storefront-customizer' );
+            } elseif ( $rarity === 'limited-edition' && empty( $edition_no ) && empty( $edition_size ) ) {
+                $parts[] = __( 'Closed Edition', 'art-storefront-customizer' );
+            } elseif ( $rarity === 'limited-edition' ) {
+                $parts[] = __( 'Closed Edition', 'art-storefront-customizer' );
+            }
+            ?>
+            <li><strong><?php esc_html_e( 'Edition', 'art-storefront-customizer' ); ?>:</strong> <?php echo esc_html( implode( ' ', $parts ) ); ?></li>
         <?php endif; ?>
         <?php if ( $framed = get_post_meta( get_the_ID(), '_asc_framed', true ) ) : ?>
             <li><strong>Framed:</strong> <?php echo esc_html( $framed ); ?></li>


### PR DESCRIPTION
## Summary
- show badges directly under the artwork title
- display edition information for limited and open editions
- hide WooCommerce out-of-stock notices for one-of-a-kind pieces
- bump plugin version to 0.1.1

## Testing
- `php -l includes/availability.php`
- `php -l templates/single-product-artwork.php`
- `php -l includes/display-fields.php`
- `php -l art-storefront-customizer.php`

------
https://chatgpt.com/codex/tasks/task_e_68865a1ba9108320b832c20dac395930