### PR TITLE
Move artwork details to Additional Information tab

### DIFF
--- a/includes/display-fields.php
+++ b/includes/display-fields.php
@@ -4,10 +4,11 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Output artwork detail meta fields on the single product page.
+ * Output artwork detail meta fields on the product page.
  *
- * Retrieves custom meta values and displays them as a list after the
- * product price. Only values that exist will be shown.
+ * Retrieves custom meta values and displays them in the WooCommerce
+ * "Additional Information" section. Only values that exist will be
+ * shown.
  */
 function asc_output_artwork_details() {
     global $product;
@@ -31,39 +32,73 @@ function asc_output_artwork_details() {
     $edition_no = get_post_meta($post_id, '_asc_edition_number', true);
     $edition_sz = get_post_meta($post_id, '_asc_edition_size', true);
 
-    $items = array();
+    $rows = array();
 
     if ($medium) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Medium', 'art-storefront-customizer'), esc_html($medium));
+        $rows[] = array(
+            'label' => __('Medium', 'art-storefront-customizer'),
+            'value' => $medium,
+        );
     }
     if ($year) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Year Created', 'art-storefront-customizer'), esc_html($year));
+        $rows[] = array(
+            'label' => __('Year Created', 'art-storefront-customizer'),
+            'value' => $year,
+        );
     }
     if ($dimensions) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Dimensions', 'art-storefront-customizer'), esc_html($dimensions));
+        $rows[] = array(
+            'label' => __('Dimensions', 'art-storefront-customizer'),
+            'value' => $dimensions,
+        );
     }
     if ($rarity) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Rarity', 'art-storefront-customizer'), esc_html($rarity));
+        $rows[] = array(
+            'label' => __('Rarity', 'art-storefront-customizer'),
+            'value' => $rarity,
+        );
     }
     if ($framed) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Framed', 'art-storefront-customizer'), esc_html($framed));
+        $rows[] = array(
+            'label' => __('Framed', 'art-storefront-customizer'),
+            'value' => $framed,
+        );
     }
     if (!empty($settings['enable_framing_options']) && $frame) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Frame Option', 'art-storefront-customizer'), esc_html($frame));
+        $rows[] = array(
+            'label' => __('Frame Option', 'art-storefront-customizer'),
+            'value' => $frame,
+        );
     }
     if ($coa) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Certificate of Authenticity', 'art-storefront-customizer'), esc_html__('Included', 'art-storefront-customizer'));
+        $rows[] = array(
+            'label' => __('Certificate of Authenticity', 'art-storefront-customizer'),
+            'value' => __('Included', 'art-storefront-customizer'),
+        );
     }
     if ($shipping) {
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Shipping Format', 'art-storefront-customizer'), esc_html($shipping));
+        $rows[] = array(
+            'label' => __('Shipping Format', 'art-storefront-customizer'),
+            'value' => $shipping,
+        );
     }
     if (!empty($settings['enable_edition_print_fields']) && ($edition_no || $edition_sz)) {
-        $value = trim($edition_no . ($edition_sz ? ' / ' . $edition_sz : ''));
-        $items[] = sprintf('<li><strong>%s:</strong> %s</li>', esc_html__('Edition', 'art-storefront-customizer'), esc_html($value));
+        $value   = trim($edition_no . ($edition_sz ? ' / ' . $edition_sz : ''));
+        $rows[] = array(
+            'label' => __('Edition', 'art-storefront-customizer'),
+            'value' => $value,
+        );
     }
 
-    if (!empty($items)) {
-        echo '<ul class="asc-artwork-details">' . implode("\n", $items) . '</ul>';
+    if (!empty($rows)) {
+        echo '<table class="shop_attributes asc-artwork-details">';
+        foreach ($rows as $row) {
+            echo '<tr>'
+                . '<th class="woocommerce-product-attributes-item__label">' . esc_html($row['label']) . '</th>'
+                . '<td class="woocommerce-product-attributes-item__value">' . esc_html($row['value']) . '</td>'
+                . '</tr>';
+        }
+        echo '</table>';
     }
 }
-add_action('woocommerce_single_product_summary', 'asc_output_artwork_details', 20);
+add_action('woocommerce_product_additional_information', 'asc_output_artwork_details', 20);


### PR DESCRIPTION
## Summary
- display artwork details in the WooCommerce **Additional Information** section
- render details as a table for consistency

## Testing
- `php -l includes/display-fields.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68865a8bc4648320a0544bf355046eeb