### PR TITLE
Improve plugin initialization and translation loading

### DIFF
--- a/art-storefront-customizer.php
+++ b/art-storefront-customizer.php
@@ -14,17 +14,40 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly.
 }
 
-require_once plugin_dir_path(__FILE__) . 'includes/meta-boxes.php';
-require_once plugin_dir_path(__FILE__) . 'includes/display-fields.php';
-require_once plugin_dir_path(__FILE__) . 'includes/taxonomies.php';
-require_once plugin_dir_path(__FILE__) . 'includes/badges.php';
 require_once plugin_dir_path(__FILE__) . 'includes/artist-profile.php';
-require_once plugin_dir_path(__FILE__) . 'includes/admin-tools.php';
 require_once plugin_dir_path(__FILE__) . 'includes/settings-page.php';
-require_once plugin_dir_path(__FILE__) . 'includes/language-overrides.php';
-require_once plugin_dir_path(__FILE__) . 'includes/template-overrides.php';
-require_once plugin_dir_path(__FILE__) . 'includes/availability.php';
 require_once plugin_dir_path(__FILE__) . 'uninstall.php';
+
+/**
+ * Load plugin textdomain for translations.
+ */
+function asc_load_textdomain() {
+    load_plugin_textdomain(
+        'art-storefront-customizer',
+        false,
+        dirname(plugin_basename(__FILE__)) . '/languages'
+    );
+}
+add_action('init', 'asc_load_textdomain');
+
+/**
+ * Include WooCommerce dependent functionality when WooCommerce is active.
+ */
+function asc_include_woocommerce_features() {
+    if (!class_exists('WooCommerce')) {
+        return;
+    }
+
+    require_once plugin_dir_path(__FILE__) . 'includes/meta-boxes.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/display-fields.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/taxonomies.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/badges.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/admin-tools.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/language-overrides.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/template-overrides.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/availability.php';
+}
+add_action('plugins_loaded', 'asc_include_woocommerce_features');
 
 register_uninstall_hook(__FILE__, 'asc_customizer_uninstall');
 

--- a/includes/badges.php
+++ b/includes/badges.php
@@ -7,6 +7,10 @@ if (!defined('ABSPATH')) {
  * Display custom badges below the product price on single product pages.
  */
 function asc_display_product_badges() {
+    if (!class_exists('WC_Product')) {
+        return;
+    }
+
     global $product;
 
     if (!$product instanceof WC_Product) {

--- a/includes/display-fields.php
+++ b/includes/display-fields.php
@@ -10,6 +10,10 @@ if (!defined('ABSPATH')) {
  * product price. Only values that exist will be shown.
  */
 function asc_output_artwork_details() {
+    if (!class_exists('WC_Product')) {
+        return;
+    }
+
     global $product;
 
     if (!$product instanceof WC_Product) {


### PR DESCRIPTION
## Summary
- load translations during `init`
- load WooCommerce-related features only when WooCommerce is active
- guard badge and display hooks against missing `WC_Product`

## Testing
- `php -l art-storefront-customizer.php`
- `php -l includes/badges.php`
- `php -l includes/display-fields.php`


------
https://chatgpt.com/codex/tasks/task_e_688669352e188320a3b311204fe6b533